### PR TITLE
chore: update dj-database-url and psycopg2-binary dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ INSTALL_REQUIRES = [
     "django-allow-cidr==0.7.1",
     "django-health-check==3.18.1",
     "requests==2.31.0",
-    "dj-database-url==2.1.0"
+    "dj-database-url==2.1.0",
     "psycopg2-binary==2.9.9"
 ]
 # with open(HERE / "requirements.txt") as f:


### PR DESCRIPTION
Update the dj-database-url dependency to the latest version and add psycopg2-binary version 2.9.9 to improve PostgreSQL support. This ensures compatibility with PostgreSQL databases and simplifies PostgreSQL integration with Django projects.