### PR TITLE
chore: update requests-oauthlib dependency to version 2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ INSTALL_REQUIRES = [
     "django-allow-cidr==0.7.1",
     "django-health-check==3.18.1",
     "requests==2.31.0",
+    "requests-oauthlib==2.0.0",
     "dj-database-url==2.1.0",
     "psycopg2-binary==2.9.9"
 ]


### PR DESCRIPTION
Update the requests-oauthlib dependency to version 2.0.0 in the setup.py file. This update ensures compatibility with the latest OAuth protocols and improves the OAuth integration in the project.