### PR TITLE
chore: Update BASE_DIR in settings to include omni_pro_guide/templates

### DIFF
--- a/omni_pro_base/settings/base.py
+++ b/omni_pro_base/settings/base.py
@@ -59,7 +59,7 @@ MIDDLEWARE = [
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [BASE_DIR / ("omni_pro_guide/templates")],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [


### PR DESCRIPTION
Update the BASE_DIR in the settings file to include the "omni_pro_guide/templates" directory. This change ensures that the Django templates in the "omni_pro_guide" app are correctly located and can be accessed by the project.