### PR TITLE
chore: Update ASYNC_TIMEOUT in base.py settings

### DIFF
--- a/omni_pro_base/settings/base.py
+++ b/omni_pro_base/settings/base.py
@@ -258,3 +258,5 @@ CELERY_SECONDS_TIME_TO_RETRY = env.int("CELERY_SECONDS_TIME_TO_RETRY", default=3
 CELERY_RESULT_EXTENDED = True
 CELERY_CACHE_BACKEND = "django-cache"
 CELERY_RESULT_BACKEND = "django-db"
+
+ASYNC_TIMEOUT = env.int("ASYNC_TIMEOUT", default=30)  # tiempo en segundos


### PR DESCRIPTION
Update the ASYNC_TIMEOUT value in the base.py settings file to 30 seconds. This change improves the project's functionality by setting a specific timeout for asynchronous operations.