### PR TITLE
chore: Add "rangefilter" to THIRD_PARTY_APPS in base.py settings

### DIFF
--- a/omni_pro_base/settings/base.py
+++ b/omni_pro_base/settings/base.py
@@ -43,6 +43,7 @@ THIRD_PARTY_APPS = [
     "django_celery_results",
     "omni_pro_base",
     "omni_pro_oms",
+    "rangefilter",
 ]
 
 INSTALLED_APPS = THEME_APPS + DJANGO_APPS + THIRD_PARTY_APPS

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ whitenoise==6.6.0
 argon2-cffi==23.1.0
 celery==5.3.6
 redis==5.0.1
+django-jazzmin-admin-rangefilter==1.0.0


### PR DESCRIPTION
add 'django-jazzmin-admin-rangefilter' in requirements.txt