### PR TITLE
Update list_per_page to 20 in BaseAdmin class

### DIFF
--- a/omni_pro_base/admin/base_admin.py
+++ b/omni_pro_base/admin/base_admin.py
@@ -12,6 +12,16 @@ class MixinSaveAdmin(object):
 
 class BaseAdmin(MixinSaveAdmin, admin.ModelAdmin):
     exclude = ("created_at", "updated_at")
+    list_per_page = 20
     fieldsets = (
-        (_("Audit Info"), {"fields": ("is_active","created_by", "updated_by", )}),
+        (
+            _("Audit Info"),
+            {
+                "fields": (
+                    "is_active",
+                    "created_by",
+                    "updated_by",
+                )
+            },
+        ),
     )


### PR DESCRIPTION
# NVOMS-2690 - Revisar flujo de filtros en Django
## ref 
https://omnipro.atlassian.net/browse/NVOMS-2690

## Descripción
Se ha actualizado el valor de `list_per_page` a 20 en la clase `BaseAdmin` para mejorar la paginación en el panel de administración de Django.

## Cambios
- Se ha añadido `list_per_page = 20` en la clase `BaseAdmin`.
- Se aplico formato a `fieldsets`.

## Motivación y contexto
Este cambio se realiza para mejorar el rendimiento del panel de administración de Django. Al limitar el número de elementos por página a 20, se reduce la carga en el servidor y se optimiza el tiempo de respuesta, especialmente en listas extensas de datos.

## Cómo se ha probado
- **Prueba 1**: Iniciar el servidor de desarrollo y verificar que el número de elementos por página en el panel de administración de Django es 20.
- **Prueba 2**: Usando `docker stats` se hizo seguimiento al uso de la memoria al hacer un filtro en el panel de `task`

## Tipo de cambio
- [ ] Bug fix (cambios que solucionan un problema)
- [x] Nueva característica (cambios que añaden funcionalidad)
- [ ] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [ ] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [x] Mi código sigue las directrices de estilo de este proyecto
- [x] He realizado una auto-revisión de mi propio código
- [x] He comentado mi código, especialmente en áreas difíciles de entender
- [x] He hecho cambios correspondientes en la documentación
- [x] Mis cambios no generan nuevas advertencias
- [x] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [x] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [x] Debería ser revisado por al menos un desarrollador más antes de fusionarse
