### PR TITLE
Propagar Errores de Django - NVOMS-3059

### DIFF
--- a/omni_pro_base/settings/base.py
+++ b/omni_pro_base/settings/base.py
@@ -266,3 +266,31 @@ ASYNC_TIMEOUT = env.int("ASYNC_TIMEOUT", default=30)  # tiempo en segundos
 
 # CONFIGURATION CELERY BEAT
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
+
+# CONFIGURATION LOGGING
+LOGGING_LEVEL = env.str("LOGGING_LEVEL", default="INFO")
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "verbose": {
+            "format": "[{levelname}] - [{asctime}]: {name} in line {lineno} - {message}",
+            "style": "{",
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "verbose",
+        },
+        # "file": {  # Handler for logging to a file
+        #     "class": "logging.FileHandler",
+        #     "filename": "debug.log",
+        #     "formatter": "verbose",
+        # },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": LOGGING_LEVEL,
+    },
+}


### PR DESCRIPTION
# propagar Errores de Django - NVOMS-3059

## ref <número de ticket jira + enlace>
https://omnipro.atlassian.net/browse/NVOMS-3059

## Descripción
Se han agregado configuraciones de logging al archivo `omni_pro_base/settings/base.py` para mejorar la visibilidad y trazabilidad de los logs en la aplicación.

## Cambios
- Se añadió una variable `LOGGING_LEVEL` configurable mediante la variable de entorno `LOGGING_LEVEL`, con un valor por defecto de `"INFO"`.
- Se agregó un diccionario de configuración para `LOGGING` con:
  - Formato `verbose` para los logs.
  - Un handler `console` que envía logs a la salida estándar.
  - Configuración de la raíz para que utilice el handler `console` y respete el nivel definido en `LOGGING_LEVEL`.
- Se comentaron configuraciones adicionales para manejar logs en archivo (`FileHandler`), dejando preparado su uso futuro.

## Motivación y contexto
La adición de esta configuración permite centralizar y estandarizar el manejo de logs en la aplicación, ofreciendo mayor flexibilidad al permitir que el nivel de logging sea definido por una variable de entorno. Esto facilita tanto el desarrollo como el diagnóstico en entornos de producción.

## Cómo se ha probado
- Configuración verificada en entorno local para asegurar que los logs se generan correctamente en consola.
- Pruebas manuales cambiando el nivel de logging mediante la variable de entorno para confirmar su comportamiento dinámico.

## Screenshots (si aplica)
N/A

## Tipo de cambio
- [ ] Bug fix (cambios que solucionan un problema)
- [x] Nueva característica (cambios que añaden funcionalidad)
- [ ] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [ ] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [x] Mi código sigue las directrices de estilo de este proyecto
- [x] He realizado una auto-revisión de mi propio código
- [x] He comentado mi código, especialmente en áreas difíciles de entender
- [ ] He hecho cambios correspondientes en la documentación
- [x] Mis cambios no generan nuevas advertencias
- [x] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [x] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [x] Debería ser revisado por al menos un desarrollador más antes de fusionarse