### PR TITLE
NVOMS-3151- Priorizar el envío de ordenes en una cola diferente para evitar esos retrasos

### DIFF
--- a/omni_pro_base/settings/base.py
+++ b/omni_pro_base/settings/base.py
@@ -246,28 +246,54 @@ CELERY_BROKER_URL = env.str("CELERY_BROKER_URL", default="redis://127.0.0.1:6379
 
 # QUEUE
 # Celery settings
-CELERY_NAME_QUEUE = CELERY_NAME_APP_DJANGO + "QUEUE_1"
-CELERY_HIGH_PRIORITY_QUEUE = CELERY_NAME_APP_DJANGO + "QUEUE_2"
+QUEUE_CRITICAL = "critical"
+QUEUE_HIGH = "high"
+QUEUE_MEDIUM = "medium"
+QUEUE_LOW = "low"
+QUEUE_VERY_LOW = "very_low"
 
-CELERY_TASK_DEFAULT_QUEUE = CELERY_NAME_QUEUE
-CELERY_TASK_DEFAULT_ROUTING_KEY = CELERY_NAME_QUEUE
+CELERY_NAME_QUEUE = QUEUE_MEDIUM
+CELERY_HIGH_PRIORITY_QUEUE = QUEUE_MEDIUM
+
+CELERY_TASK_DEFAULT_QUEUE = QUEUE_LOW
+CELERY_TASK_DEFAULT_ROUTING_KEY = QUEUE_LOW
 
 CELERY_TASK_QUEUES = [
     kombuQueue(
-        CELERY_NAME_QUEUE,
-        routing_key=CELERY_NAME_QUEUE,
-        queue_arguments={"x-max-priority": 10},
+        name=QUEUE_CRITICAL,
+        exchange=QUEUE_CRITICAL,
+        routing_key=QUEUE_CRITICAL,
     ),
     kombuQueue(
-        CELERY_HIGH_PRIORITY_QUEUE,
-        routing_key=CELERY_HIGH_PRIORITY_QUEUE,
-        queue_arguments={"x-max-priority": 10},
+        name=QUEUE_HIGH,
+        exchange=QUEUE_HIGH,
+        routing_key=QUEUE_HIGH,
+    ),
+    kombuQueue(
+        name=QUEUE_MEDIUM,
+        exchange=QUEUE_MEDIUM,
+        routing_key=QUEUE_MEDIUM,
+    ),
+    kombuQueue(
+        name=QUEUE_LOW,
+        exchange=QUEUE_LOW,
+        routing_key=QUEUE_LOW,
+    ),
+    kombuQueue(
+        name=QUEUE_VERY_LOW,
+        exchange=QUEUE_VERY_LOW,
+        routing_key=QUEUE_VERY_LOW,
     ),
 ]
-
 CELERY_TASK_ROUTES = {
-    f"{CELERY_NAME_APP_DJANGO}.tasks.*": {"queue": CELERY_NAME_QUEUE},
+    f"{CELERY_NAME_APP_DJANGO}.tasks.critical_*": {"queue": QUEUE_CRITICAL, "routing_key": QUEUE_CRITICAL},
+    f"{CELERY_NAME_APP_DJANGO}.tasks.high_*": {"queue": QUEUE_HIGH, "routing_key": QUEUE_HIGH},
+    f"{CELERY_NAME_APP_DJANGO}.tasks.medium_*": {"queue": QUEUE_MEDIUM, "routing_key": QUEUE_MEDIUM},
+    f"{CELERY_NAME_APP_DJANGO}.tasks.low_*": {"queue": QUEUE_LOW, "routing_key": QUEUE_LOW},
+    f"{CELERY_NAME_APP_DJANGO}.tasks.very_low_*": {"queue": QUEUE_VERY_LOW, "routing_key": QUEUE_VERY_LOW},
 }
+
+CELERY_WORKER_PREFETCH_MULTIPLIER = 1
 
 ACCEPT_CONTENT = ["json"]
 RESULT_SERIALIZER = "json"

--- a/omni_pro_base/settings/base.py
+++ b/omni_pro_base/settings/base.py
@@ -247,10 +247,23 @@ CELERY_BROKER_URL = env.str("CELERY_BROKER_URL", default="redis://127.0.0.1:6379
 # QUEUE
 # Celery settings
 CELERY_NAME_QUEUE = CELERY_NAME_APP_DJANGO + "QUEUE_1"
-CELERY_TASK_QUEUES = (kombuQueue(CELERY_NAME_QUEUE, routing_key=CELERY_NAME_QUEUE),)
+CELERY_HIGH_PRIORITY_QUEUE = CELERY_NAME_APP_DJANGO + "QUEUE_2"
 
 CELERY_TASK_DEFAULT_QUEUE = CELERY_NAME_QUEUE
 CELERY_TASK_DEFAULT_ROUTING_KEY = CELERY_NAME_QUEUE
+
+CELERY_TASK_QUEUES = [
+    kombuQueue(
+        CELERY_NAME_QUEUE,
+        routing_key=CELERY_NAME_QUEUE,
+        queue_arguments={"x-max-priority": 10},
+    ),
+    kombuQueue(
+        CELERY_HIGH_PRIORITY_QUEUE,
+        routing_key=CELERY_HIGH_PRIORITY_QUEUE,
+        queue_arguments={"x-max-priority": 10},
+    ),
+]
 
 CELERY_TASK_ROUTES = {
     f"{CELERY_NAME_APP_DJANGO}.tasks.*": {"queue": CELERY_NAME_QUEUE},


### PR DESCRIPTION
# NVOMS-3151- Priorizar el envío de ordenes en una cola diferente para evitar esos retrasos

## ref NVOMS-3151 https://omnipro.atlassian.net/browse/NVOMS-3151

## Descripción
- Este PR agrega la cola CELERY_HIGH_PRIORITY_QUEUE en los settings base.

## Cambios
- Añadido la cola para priorizar task y seañadio en queque_arguments el priority.

## Motivación y contexto
Estos cambios son necesarios para priorizar tareas.

## Cómo se ha probado
-  Se realizaron pruebas compilando la nueva versión de la librería.

## Screenshots (si aplica)
N/A

## Tipo de cambio
- [ ]  Bug fix (cambios que solucionan un problema)
- [x] Nueva característica (cambios que añaden funcionalidad)
- [ ] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [ ] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [x] Mi código sigue las directrices de estilo de este proyecto
- [x] He realizado una auto-revisión de mi propio código
- [x] He comentado mi código, especialmente en áreas difíciles de entender
- [x] He hecho cambios correspondientes en la documentación
- [x] Mis cambios no generan nuevas advertencias
- [x] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [x] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [x] Debería ser revisado por al menos un desarrollador más antes de fusionarse

## Notas adicionales
N/A